### PR TITLE
Fix login

### DIFF
--- a/testflight_invite.py
+++ b/testflight_invite.py
@@ -178,14 +178,14 @@ class TestFlightInvite:
             if e.code == 500: # 500 if tester already exists... This is not how you HTTP, Apple.
                 raise TFInviteDuplicateException
             raise
-            
+
 def usage():
-    print 'Usage: %s <iTC login email> <App ID> <Invitee Email> <Invitee First Name (Optional)> <Invitee Last Name (Optional)'
+    print 'Usage: %s <iTC login email> <App ID> <Invitee Email> <Invitee First Name (Optional)> <Invitee Last Name (Optional)' % sys.argv[0]
 
 def main():
     if len(sys.argv) < 4:
         usage()
-        return -1 
+        return -1
 
     itcLogin = sys.argv[1]
 
@@ -221,4 +221,3 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/testflight_invite.py
+++ b/testflight_invite.py
@@ -135,8 +135,7 @@ class TestFlightInvite:
             data=json.dumps(data),
             headers=headers
         )
-        self.readData("https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/wa/route?noext")
-        self.readData("https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa")    
+        self.readData("https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/wa")
 
     def numTesters(self):
         self.login()


### PR DESCRIPTION
Login was failing with an HTTP 500 error from Apple. I looked at how `spaceship` does it and changed the URL we hit.

Tested with one user; the email address was indeed added to the list of external testers.

Also made a small unrelated change to CLI usage info, in second commit.